### PR TITLE
Killing multiple workers on each iteration of reaper, if needed

### DIFF
--- a/test/puma_worker_killer_test.rb
+++ b/test/puma_worker_killer_test.rb
@@ -31,6 +31,7 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
 
     WaitForIt.new(command, options) do |spawn|
       assert_contains(spawn, 'Out of memory')
+      assert_contains(spawn, /Releasing .* from 2 workers/)
     end
   end
 


### PR DESCRIPTION
Current `reap()` method picks only one single `puma` worker and terminates that to free memory. However, in many cases, this would not be sufficient to bring the `total` memory to under `max_ram`. And then the system would have to wait for the subsequent cycles for this to happen.

This is not very optimal. In this proposed change, in each cycle, enough workers will be selected and terminated until the total consumed memory by `puma` is below the desired threshold.

The log outputs have slightly changed to indicate this. Example:

```
[5447] PumaWorkerKiller: Out of memory. 10 workers consuming total: 6500.63671875 mb out of max: 1980.0 mb. Releasing 4729.95703125 mb from 8 workers.
        Sending TERM to pid 5469 consuming 591.75390625 mb.
        Sending TERM to pid 5478 consuming 591.63671875 mb.
        Sending TERM to pid 5473 consuming 591.59375 mb.
        Sending TERM to pid 5471 consuming 591.3515625 mb.
        Sending TERM to pid 5547 consuming 591.171875 mb.
        Sending TERM to pid 5545 consuming 590.98046875 mb.
        Sending TERM to pid 5549 consuming 590.88671875 mb.
        Sending TERM to pid 5623 consuming 590.58203125 mb.

```